### PR TITLE
Update Dependencies

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -14,7 +14,7 @@
     </dependency>
     <!-- Media -->
     <dependency name="media" linkPath="media">
-        <package name="falcor_media" version="7accd221" />
+        <package name="falcor_media" version="7acdf8b0" />
     </dependency>
     <!-- Libraries -->
     <dependency name="falcor_dependencies" linkPath="external/packman/deps">
@@ -40,9 +40,6 @@
     </dependency>
     <dependency name="agility-sdk" linkPath="external/packman/agility-sdk">
         <package name="agility-sdk" version="1.4.10" platforms="windows-x86_64"/>
-    </dependency>
-    <dependency name="nvapi" linkPath="external/packman/nvapi">
-        <package name="nvapi" version="r535-developer-${platform}" platforms="windows-x86_64" />
     </dependency>
     <dependency name="nvtt" linkPath="external/packman/nvtt">
         <package name="nvtt" version="3.1.6-${platform}" platforms="windows-x86_64 linux-x86_64" />


### PR DESCRIPTION
The requested versions of ``falcor_media`` and ``nvapi`` are no longer available. This PR bumps ``falcor_media`` and removes ``nvapi`` to match mainline Falcor, so that the project can be built out-of-the-box.