### PR TITLE
Fix Lightweight BDPT

### DIFF
--- a/Source/RenderPasses/ReSTIRBDPT/PathReservoir.slang
+++ b/Source/RenderPasses/ReSTIRBDPT/PathReservoir.slang
@@ -82,8 +82,8 @@ struct LightSubpathData {
 struct RecursiveMisState {
     float dVCM = 0;
     float dVC = 0;
+    float dVM = 0;
     uint  flag = 0;
-    uint  pad = 0;
 };
 struct ReconnectionMisState {
     float invFwdG_r = 0;


### PR DESCRIPTION
When ``disableVC`` is toggled, the code fails to compile because of a missing reference to ``dVM``. This PR replaces the ``pad`` variable with a dummy ``dVM`` variable to resolve the compilation error.